### PR TITLE
Correct spelling and add support for gems.rb

### DIFF
--- a/Source/Scripts/RuboCopProcess.js
+++ b/Source/Scripts/RuboCopProcess.js
@@ -18,8 +18,8 @@ class RuboCopProcess {
             return Promise.resolve(this._isBundled);
         }
 
-        if (!nova.workspace.contains("Gemfile")) {
-            this._sisBundled = false;
+        if (!(nova.workspace.contains("Gemfile") || nova.workspace.contains("gems.rb"))) {
+            this._isBundled = false;
             return Promise.resolve(false);
         }
 


### PR DESCRIPTION
Though it's not super well documented, Bundler supports an alternative name for the `Gemfile` that's `gems.rb` which we should look for when determining if a workspace is bundled or not. [This post](https://depfu.com/blog/2017/09/06/gemfiles-new-clothes) gives a little overview and has some more links as well.