### PR TITLE
Passes relative path to rubocop

### DIFF
--- a/Source/Scripts/Linter.js
+++ b/Source/Scripts/Linter.js
@@ -20,7 +20,7 @@ class Linter {
         const contentRange = new Range(0, document.length);
         const content = document.getTextInRange(contentRange);
 
-        return this.lintString(content, document.uri);
+        return this.lintString(content, document.path);
     }
 
     async lintString(string, uri) {

--- a/Source/Scripts/RuboCopProcess.js
+++ b/Source/Scripts/RuboCopProcess.js
@@ -97,7 +97,7 @@ class RuboCopProcess {
         if (workspaceOverlap != -1) {
             relativePath = uri.substring(workspaceOverlap + nova.workspace.path.length + 1);
         } else {
-            relativePath = uri
+            relativePath = uri;
         }
         
         const defaultArguments = [
@@ -106,7 +106,6 @@ class RuboCopProcess {
             "--stdin",
             relativePath
         ];
-        
         const process = await this.process(defaultArguments);
         if (!process) return;
 

--- a/Source/Scripts/RuboCopProcess.js
+++ b/Source/Scripts/RuboCopProcess.js
@@ -91,13 +91,22 @@ class RuboCopProcess {
     }
 
     async execute(content, uri) {
+        let workspaceOverlap = uri.indexOf(nova.workspace.path);
+        let relativePath = '';
+        
+        if (workspaceOverlap != -1) {
+            relativePath = uri.substring(workspaceOverlap + nova.workspace.path.length + 1);
+        } else {
+            relativePath = uri
+        }
+        
         const defaultArguments = [
             "rubocop",
             "--format=json",
             "--stdin",
-            uri
+            relativePath
         ];
-
+        
         const process = await this.process(defaultArguments);
         if (!process) return;
 


### PR DESCRIPTION
Fixes: #10 

This tries to form a relative path based on the relationship to the root of the workspace directory. If it can do so, it uses that as the path that is given to the `--path` argument for `rubocop`. This allows inclusions and exclusions to work.

I'm not 100% happy with the path comparison, but it works. The paths that come from the file object seem to include the `/Volumes/Macintosh HD/Users` prefix while the workspace just starts with `/Users`. So I kind of just ignore that.

Open to suggestions.