### PR TITLE
Find the json in the process output

### DIFF
--- a/Source/Scripts/RuboCopProcess.js
+++ b/Source/Scripts/RuboCopProcess.js
@@ -144,7 +144,8 @@ class RuboCopProcess {
         }
 
         try {
-            const parsedOutput = JSON.parse(output);
+            const jsonString = output.substring(output.indexOf("{"));
+            const parsedOutput = JSON.parse(jsonString);
             const offenses = parsedOutput["files"][0]["offenses"];
     
             // TODO: Enable a "Debug" Preference


### PR DESCRIPTION
Fixes #14 

In my case I have a different shell running that outputs some info, when started, like so: 

```
RuboCop[22:09:57.120000] 
                 ###                  User: tim
               ####                   Hostname: Tims-MacBook-Pro.fritz.box
               ###                    Distro: OS X 10.15.6
       #######    #######             Kernel: Darwin
     ######################           Uptime: 10 days
    #####################             Shell: /usr/local/bin/fish
    ####################              Terminal: dumb 
    ####################              CPU: Intel Core i7-8559U CPU @ 2.70GHz
    #####################             Memory: 16 GB
     ######################           Disk: 11%
      ####################            Battery: 99.23%
        ################              IP Address: 217.233.218.202
         ####     #####               


{"metadata":{"rubocop_version":"0.93.0","ruby_engine":"ruby","ruby_version":"2.7.1","ruby_patchlevel":"83","ruby_platform":"x86_64-darwin19"},"files":[{"path":"app/controllers/recommendations_controller.rb","offenses":[{"severity":"conven...
```

So it might be useful to first find the json in the process output an then parse it.